### PR TITLE
Check the app platform in addition to the bundleid

### DIFF
--- a/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
+++ b/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
@@ -72,7 +72,7 @@ module Fastlane
         apps_response = JSON.parse(response.body)
 
         apps_response['apps'].each do |app|
-          if app['bundle_identifier'] == bundle_id
+          if app['bundle_identifier'] == bundle_id and app['platform'] == 'iOS'
             app_public_id = app['public_identifier']
           end
         end


### PR DESCRIPTION
Just in case there is an android and ios app with the same bundle id, the platform should be used to filter the app list so only ios apps are considered.