### PR TITLE
Remove trailing period from description

### DIFF
--- a/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
+++ b/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
@@ -34,7 +34,7 @@ module Fastlane
                                        env_name: 'FL_HOCKEY_API_TOKEN',
                                        description: 'API Token for Hockey'),
           FastlaneCore::ConfigItem.new(key: :app_bundle_id,
-                                       description: 'App bundle identifier to get unprovisioned devices for (example: com.company.AppName).')
+                                       description: 'App bundle identifier to get unprovisioned devices for (example: com.company.AppName)')
         ]
       end
 


### PR DESCRIPTION
Otherwise fastlane complains:  `Do not let descriptions end with a '.', since it's used for user inputs as well`