### PR TITLE
Trim device names

### DIFF
--- a/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
+++ b/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         hockey_app_id = hockey_app_id_for_bundle_id(bundle_id, api_token)
         if hockey_app_id.empty?
-          UI.user_error! "Could not find an app in Hockey with bundle ID matching #{bundle_id}"
+          UI.abort_with_message! "Could not find an app in Hockey with bundle ID matching #{bundle_id}"
         end
 
         devices = unprovisioned_devices_for_hockey_app_id(hockey_app_id, api_token)

--- a/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
+++ b/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
@@ -11,7 +11,7 @@ module Fastlane
 
         hockey_app_id = hockey_app_id_for_bundle_id(bundle_id, api_token)
         if hockey_app_id.empty?
-          UI.abort_with_message! "Could not find an app in Hockey with bundle ID matching #{bundle_id}"
+          UI.user_error! "Could not find an app in Hockey with bundle ID matching #{bundle_id}"
         end
 
         devices = unprovisioned_devices_for_hockey_app_id(hockey_app_id, api_token)

--- a/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
+++ b/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
@@ -92,7 +92,7 @@ module Fastlane
         end
 
         devices_response = JSON.parse(response.body)['devices']
-        Hash[devices_response.collect { |item| [item['name'], item['udid']] }]
+        Hash[devices_response.collect { |item| [item['name'][0..49], item['udid']] }]
       end
     end
   end


### PR DESCRIPTION
Apparently register_devices only allows a max of [50 characters for a device name](https://github.com/fastlane/fastlane/blob/ef2e1e4e00e0d0db9809d187dad7be18cf026ad1/spaceship/lib/spaceship/portal/device.rb#L151).  Since the output of get_unprovisioned_devices_from_hockey is expected to be passed directly into register_devices, it makes sense to truncate any names that are longer than that.