### PR TITLE
Trim device names

### DIFF
--- a/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
+++ b/lib/fastlane/plugin/get_unprovisioned_devices_from_hockey/actions/get_unprovisioned_devices_from_hockey_action.rb
@@ -92,7 +92,7 @@ module Fastlane
         end
 
         devices_response = JSON.parse(response.body)['devices']
-        Hash[devices_response.collect { |item| [item['name'], item['udid']] }]
+        Hash[devices_response.collect { |item| [item['name'][0..49], item['udid']] }]
       end
     end
   end


### PR DESCRIPTION
Apparently register_devices only allows a max of 50 characters for a device name. Since the output of get_unprovisioned_devices_from_hockey is expected to be passed directly into register_devices, it makes sense to truncate any names that are longer than that.